### PR TITLE
Task4/fruits veggies section filters

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,7 +25,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/assets/seasonal_metadata.json
+++ b/app/src/main/assets/seasonal_metadata.json
@@ -130,7 +130,7 @@
     "Name": "Boysenberries",
     "Type": "Fruit",
     "Description": "The boysenberry is a cross among the European raspberry, European blackberry, American dewberry, and loganberry. Boysenberries are characterized by their soft texture, thin skins, and sweet-tart flavor. Mature fruits leak juice very easily and can start to decay within a few days of harvest. Boysenberries are a rich source of vitamin C and dietary fiber but are low in other essential nutrients.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -139,7 +139,7 @@
     "Name": "Brambles",
     "Type": "Fruit",
     "Description": "In British English, a bramble is any rough tangled prickly shrub, but specifically refers to the blackberry bush. Bramble or brambleberry may also refer to the blackberry fruit or products of its fruit, for example bramble jelly.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -166,7 +166,7 @@
     "Name": "Burdock",
     "Type": "Vegetable",
     "Description": "The taproot of young burdock plants can be harvested and eaten as a root vegetable. Native to Europe and Asia, several species have been widely introduced worldwide. Burdock root is very crisp and has a sweet, mild, pungent flavor with a little muddy harshness that can be reduced by soaking julienned or shredded roots in water for five or ten minutes. Burdock seeds or burrs are covered in small hooks and were the inspiration for Velcro.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -193,7 +193,7 @@
     "Name": "Cardoons",
     "Type": "Vegetable",
     "Description": "The cardoon is also called the artichoke thistle or globe artichoke, is part of the sunflower family. It is native to the western and central Mediterranean region, where it was domesticated in ancient times. While the flower buds can be eaten as small artichokes, more often the stems are eaten after being braised in cooking liquid. They have an artichoke-like flavor with a hint of bitterness. They are a good source of folate, magnesium and manganese.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -229,7 +229,7 @@
     "Name": "Celery Root",
     "Type": "Vegetable",
     "Description": "Celery root is also called turnip-rooted celery, or knob celery. It is a variety of celery cultivated for its edible roots, stem, and shoots, and originated in the Mediterranean Basin. It is edible raw or cooked, and tastes similar to the stalks of common celery. It may be roasted, stewed, blanched, or mashed. It is a rich source of vitamin K and a good source of vitamin B6, vitamin C and phosphorus.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -274,7 +274,7 @@
     "Name": "Chicories",
     "Type": "Vegetable",
     "Description": "Common, also known as blue daisy, coffeeweed, horseweed, succory and wild endive, is a perennial herbaceous plant of the dandelion family native to Europe. Many varieties are cultivated for salad leaves which usually have a bitter taste. The roots can be baked and ground, and used as a coffee substitute and additive. Chicory is a rich source of vitamin A, vitamin B5, folate, vitamin C and especially vitamin K.  It is also a good source of calcium and manganese.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -310,7 +310,7 @@
     "Name": "Citrus",
     "Type": "Fruit",
     "Description": "Citrus is a genus of flowering trees and shrubs in the rue family, Rutaceae. Plants in the genus produce citrus fruits, including important crops like oranges, lemons, grapefruit, pomelo and limes. They are eaten fresh and typically peeled and can be easily split into segments.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -571,7 +571,7 @@
     "Name": "Lamb's Quarters",
     "Type": "Vegetable",
     "Description": "Lamb's quarter is another name for various edible species of goosefoot, or pigweed. The goosefoot family contains several plants used as leaf vegetables in the manner of the closely related spinach. The goosefoot family also includes quinoa, which has increasing importance in a gluten-free diet.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "hhttp://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -652,7 +652,7 @@
     "Name": "Melons",
     "Type": "Fruit",
     "Description": "A melon fruit is actually a kind of berry. Melons originated in Africa and southwest Asia, and began to appear in Europe toward the end of the Western Roman Empire. Melons were among the earliest plants to be domesticated in both the Old and New Worlds. Fresh cantaloupe is a rich source of vitamin C and vitamin A, with other nutrients in negligible amounts.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -715,7 +715,7 @@
     "Name": "Nopales",
     "Type": "Vegetable",
     "Description": "Nopal is a common name in Mexican Spanish for Opuntia cacti, commonly referred to in English as prickly pear. The nopal pads can be eaten raw or cooked, used in marmalades, soups stews and salads. Nopales have a light, slightly tart flavor, like green beans, and a crisp texture. They are an excellent source of manganese and a good source of vitamin C.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -796,7 +796,7 @@
     "Name": "Pea Shoots",
     "Type": "Vegetable",
     "Description": "Pea shoots are the young and tender shoots and leaves of the pea vine. They retain the taste of fresh peas. They can be eaten raw in salads and can be cooked, and are especially good when cooked quickly and simply in stir fries.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -967,7 +967,7 @@
     "Name": "Ramps",
     "Type": "Vegetable",
     "Description": "Ramps, also known as spring onion, ramson, wild leek, and wild garlic, is a North American species of wild onion. It is regarded as an early spring vegetable with a strong garlic-like odor and a pronounced onion flavor.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -976,7 +976,7 @@
     "Name": "Rapini",
     "Type": "Vegetable",
     "Description": "Rapini, also known as broccoli raab or broccoli rabe, is a green cruciferous vegetable, related to the cabbage, with edible leave, buds, and stems. The flavor of rapini is nutty, bitter, and pungent and also reminiscent of mustard greens. It is particularly associated with Italian, and Portuguese cuisines.  It is an excellent source of vitamin K, a rich source of folate and vitamin C, and a good source of vitamin A, thiamine, riboflavin, vitamin B6, iron, manganese and phosphorus.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -1030,7 +1030,7 @@
     "Name": "Salsify",
     "Type": "Vegetable",
     "Description": "Salsify is commonly known as oyster plant, Jerusalem star or goatsbeard. It is a common biennial wildflower, native to Mediterranean regions of Europe. The root, and sometimes the young shoots are used as a vegetable. The root is noted for tasting of oysters, but more insipid with a touch of sweetness. The young shoots of purple salsify can also be eaten, as well as young leaves .",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -1048,7 +1048,7 @@
     "Name": "Shell Beans",
     "Type": "Legume",
     "Description": "Shell beans are any of the varieties of beans whose pods are removed and typically not eaten. Popular varieties include fava or broad beans, cranberry or borlotti beans, lima beans, chickpeas or garbanzo beans, black beans, and scarlet runner beans. Fresh shell beans have a sweet and creamy taste and can be prepared in the same ways as their dried counterparts, but take less time to cook.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -1075,7 +1075,7 @@
     "Name": "Sorrel",
     "Type": "Vegetable",
     "Description": "Common sorrel or garden sorrel is a perennial herb. It is a common plant in grassland habitats and is cultivated as a garden herb or salad vegetable. The leaves may be puréed in soups and sauces or added to salads; they have a flavour that is similar to kiwifruit or sour wild strawberries. The plant's sharp taste is due to oxalic acid, which is mildly toxic.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },
@@ -1120,7 +1120,7 @@
     "Name": "Sunchokes",
     "Type": "Vegetable",
     "Description": "The sunchoke, also called sunroot, Jerusalem artichoke, earth apple, or topinambour, is a species of sunflower native to eastern North America. They are rich in the carbohydrate inulin and sunchoke tubers stored for any length of time convert their inulin into its component fructose, which gives them a sweet taste. Sunchoke are high in potassium and iron, and have significant amounts of niacin, thiamine, phosphorus, and copper.",
-    "imgURL": "https://unsplash.com/photos/wOHH-NUTvVc",
+    "imgURL": "http://i67.tinypic.com/3346yrk.jpg",
     "Attribution": "",
     "Display": false
   },

--- a/app/src/main/java/com/example/seetha/seasonalclone/adapters/SeasonalAdapter.kt
+++ b/app/src/main/java/com/example/seetha/seasonalclone/adapters/SeasonalAdapter.kt
@@ -1,33 +1,92 @@
 package com.example.seetha.seasonalclone.adapters
 
 import android.support.v7.widget.RecyclerView
-import android.view.View
 import android.view.ViewGroup
 import com.example.seetha.seasonalclone.models.ProduceItem
 import views.BrowseItemView
+import views.HeaderItemView
 
-class SeasonalAdapter(private var items: List<ProduceItem>) : RecyclerView.Adapter<SeasonalAdapter.ViewHolder>() {
+class SeasonalAdapter(private var items: List<ProduceItem>) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+
+    val FRUIT_TYPE = "Fruit"
+    val VEGETABLE_TYPE = "Vegetable"
+    val HERB_TYPE = "Herb"
+    val LEGUME_TYPE = "Legume"
+    val NUT_TYPE = "Nut"
+
+    private val itemsWithHeaders = sortItemsByHeader(items)
 
     init {
         notifyDataSetChanged()
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val itemView = BrowseItemView.inflate(parent)
-        return ViewHolder(itemView)
+    private fun sortItemsByHeader(items: List<ProduceItem>): List<Any> {
+
+        val displayItems = items.filter { item -> item.display }
+        val sortedProduce = mutableListOf<Any>()
+        if (displayItems.isNotEmpty()) {
+            sortedProduce.add(0, "Fruits")
+            sortedProduce.addAll(displayItems.filter { displayItem -> displayItem.type == FRUIT_TYPE })
+        }
+        if (items.isNotEmpty()) {
+            sortedProduce.add("Veggies")
+            sortedProduce.addAll(displayItems.filter { displayItem ->
+                listOf(VEGETABLE_TYPE, HERB_TYPE, LEGUME_TYPE, NUT_TYPE).contains(displayItem.type)
+            })
+        }
+
+        return sortedProduce
+
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.browseItemView.produce = items[position]
+    companion object {
+        private const val VIEW_TYPE_HEADER = 0
+        private const val VIEW_TYPE_ITEM = 1
+    }
+
+
+    override fun getItemViewType(position: Int): Int {
+        if (itemsWithHeaders[position] is ProduceItem) {
+            return VIEW_TYPE_ITEM
+        }
+
+        return VIEW_TYPE_HEADER
+    }
+
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+
+        return when (viewType) {
+            VIEW_TYPE_ITEM -> {
+                val view = BrowseItemView.inflate(parent)
+                SimpleViewHolder(view)
+            }
+            else -> {
+                val headerView = HeaderItemView.inflate(parent)
+                SimpleViewHolder(headerView)
+            }
+        }
+
 
     }
 
-    override fun getItemCount(): Int {
-        return items.size
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder.itemViewType) {
+            VIEW_TYPE_ITEM -> {
+                val itemHolder = holder as SimpleViewHolder<BrowseItemView>
+                itemHolder.view.produce = itemsWithHeaders[position] as ProduceItem
+            }
+            VIEW_TYPE_HEADER -> {
+                val headerHolder = holder as SimpleViewHolder<HeaderItemView>
+                headerHolder.view.header = itemsWithHeaders[position].toString()
+            }
+
+        }
     }
 
-    inner class ViewHolder(v: View) : RecyclerView.ViewHolder(v) {
-        internal val browseItemView: BrowseItemView = v as BrowseItemView
-    }
+    override fun getItemCount(): Int = itemsWithHeaders.size
+
 
 }

--- a/app/src/main/java/com/example/seetha/seasonalclone/adapters/SeasonalAdapter.kt
+++ b/app/src/main/java/com/example/seetha/seasonalclone/adapters/SeasonalAdapter.kt
@@ -6,8 +6,7 @@ import com.example.seetha.seasonalclone.models.ProduceItem
 import views.BrowseItemView
 import views.HeaderItemView
 
-class SeasonalAdapter(private var items: List<ProduceItem>) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-
+class SeasonalAdapter(private val items: List<ProduceItem>) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     val FRUIT_TYPE = "Fruit"
     val VEGETABLE_TYPE = "Vegetable"
@@ -26,10 +25,8 @@ class SeasonalAdapter(private var items: List<ProduceItem>) : RecyclerView.Adapt
         val displayItems = items.filter { item -> item.display }
         val sortedProduce = mutableListOf<Any>()
         if (displayItems.isNotEmpty()) {
-            sortedProduce.add(0, "Fruits")
+            sortedProduce.add( "Fruits")
             sortedProduce.addAll(displayItems.filter { displayItem -> displayItem.type == FRUIT_TYPE })
-        }
-        if (items.isNotEmpty()) {
             sortedProduce.add("Veggies")
             sortedProduce.addAll(displayItems.filter { displayItem ->
                 listOf(VEGETABLE_TYPE, HERB_TYPE, LEGUME_TYPE, NUT_TYPE).contains(displayItem.type)

--- a/app/src/main/java/com/example/seetha/seasonalclone/adapters/SimpleViewHolder.kt
+++ b/app/src/main/java/com/example/seetha/seasonalclone/adapters/SimpleViewHolder.kt
@@ -1,0 +1,10 @@
+package com.example.seetha.seasonalclone.adapters
+
+import android.support.v7.widget.RecyclerView
+import android.view.View
+
+@Suppress("UNCHECKED_CAST")
+class SimpleViewHolder<out T : View>(itemView: T) : RecyclerView.ViewHolder(itemView) {
+    val view: T
+        get() = itemView as T
+}

--- a/app/src/main/java/com/example/seetha/seasonalclone/models/ClientModel.kt
+++ b/app/src/main/java/com/example/seetha/seasonalclone/models/ClientModel.kt
@@ -7,7 +7,8 @@ data class ProduceItem(
         @SerializedName("Name") val name: String,
         @SerializedName("Type") val type: String,
         @SerializedName("Description") val description: String,
-        @SerializedName("imgURL") val imgURL: String
+        @SerializedName("imgURL") val imgURL: String,
+        @SerializedName("Display") val display: Boolean
 
 )
 

--- a/app/src/main/java/views/HeaderItemView.kt
+++ b/app/src/main/java/views/HeaderItemView.kt
@@ -1,0 +1,36 @@
+package views
+
+import android.content.Context
+import android.support.annotation.AttrRes
+import android.support.annotation.StyleRes
+import android.util.AttributeSet
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import kotterknife.bindView
+import com.example.seetha.seasonalclone.R
+import com.example.seetha.seasonalclone.util.inflate
+
+
+internal class HeaderItemView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        @AttrRes defStyleAttr: Int = 0,
+        @StyleRes defStyleRes: Int = 0
+) : LinearLayout(context, attrs, defStyleAttr, defStyleRes) {
+
+    private val headerText: TextView by bindView(R.id.tvHeader)
+
+    companion object {
+        fun inflate(parent: ViewGroup): HeaderItemView = parent.context.inflate(
+                R.layout.item_header, parent, false) as HeaderItemView
+    }
+
+    var header: String? = null
+        set(value) {
+            field = value
+            headerText.text = value
+
+        }
+
+}

--- a/app/src/main/res/layout/item_header.xml
+++ b/app/src/main/res/layout/item_header.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<views.HeaderItemView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/browseItemView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/white">
+
+    <TextView
+        android:id="@+id/tvHeader"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignStart="@+id/tvName"
+        android:layout_below="@+id/tvName"
+        android:layout_marginBottom="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="24dp"
+        android:letterSpacing="0.03"
+        android:textColor="@color/black"
+        android:textSize="@dimen/large_text_size" />
+
+</views.HeaderItemView>


### PR DESCRIPTION
TASK 4: Adding filters into Fruits and Veggies Sections

- Group produce types “Herb”, “Legume”, “Nut”, and “Vegetable" all under Veggies section, and “Fruit” type into the Fruits section. The section headers should be “Veggies” and “Fruits”
- Only show items with display = true value in metadata
- *Bonus: Use a viewpager to show fruits in one tab, and veggies in another tab.
- **Bonus: Show items that are “new” this month as a separate section.